### PR TITLE
Added ability to create custom extended ProtocolProcessors and WebSocket clients

### DIFF
--- a/WebSocket4Net/Protocol/DraftHybi00Processor.cs
+++ b/WebSocket4Net/Protocol/DraftHybi00Processor.cs
@@ -11,7 +11,7 @@ namespace WebSocket4Net.Protocol
     /// <summary>
     /// http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-00
     /// </summary>
-    class DraftHybi00Processor : ProtocolProcessorBase
+    public class DraftHybi00Processor : ProtocolProcessorBase
     {
         public DraftHybi00Processor()
             : base(WebSocketVersion.DraftHybi00, new CloseStatusCodeHybi10())

--- a/WebSocket4Net/Protocol/DraftHybi10Processor.cs
+++ b/WebSocket4Net/Protocol/DraftHybi10Processor.cs
@@ -15,7 +15,7 @@ namespace WebSocket4Net.Protocol
     /// <summary>
     /// http://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-10
     /// </summary>
-    class DraftHybi10Processor : ProtocolProcessorBase
+    public class DraftHybi10Processor : ProtocolProcessorBase
     {
         private const string m_Magic = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
 

--- a/WebSocket4Net/Protocol/ProtocolProcessorBase.cs
+++ b/WebSocket4Net/Protocol/ProtocolProcessorBase.cs
@@ -5,7 +5,7 @@ using SuperSocket.ClientEngine;
 
 namespace WebSocket4Net.Protocol
 {
-    abstract class ProtocolProcessorBase : IProtocolProcessor
+    public abstract class ProtocolProcessorBase : IProtocolProcessor
     {
         protected const string HeaderItemFormat = "{0}: {1}";
 

--- a/WebSocket4Net/Protocol/Rfc6455Processor.cs
+++ b/WebSocket4Net/Protocol/Rfc6455Processor.cs
@@ -7,7 +7,7 @@ namespace WebSocket4Net.Protocol
     /// <summary>
     /// http://tools.ietf.org/html/rfc6455
     /// </summary>
-    class Rfc6455Processor : DraftHybi10Processor
+    public class Rfc6455Processor : DraftHybi10Processor
     {
         public Rfc6455Processor()
             : base(WebSocketVersion.Rfc6455, new CloseStatusCodeRfc6455())

--- a/WebSocket4Net/WebSocket.cs
+++ b/WebSocket4Net/WebSocket.cs
@@ -44,22 +44,22 @@ namespace WebSocket4Net
 
         protected const string UserAgentKey = "UserAgent";
 
-        internal IProtocolProcessor ProtocolProcessor { get; private set; }
+        protected internal IProtocolProcessor ProtocolProcessor { get; private set; }
 
         public bool SupportBinary
         {
             get { return ProtocolProcessor.SupportBinary; }
         }
 
-        internal Uri TargetUri { get; private set; }
+        protected internal Uri TargetUri { get; private set; }
 
-        internal string SubProtocol { get; private set; }
+        protected internal string SubProtocol { get; private set; }
 
-        internal IDictionary<string, object> Items { get; private set; }
+        protected internal IDictionary<string, object> Items { get; private set; }
 
-        internal List<KeyValuePair<string, string>> Cookies { get; private set; }
+        protected internal List<KeyValuePair<string, string>> Cookies { get; private set; }
 
-        internal List<KeyValuePair<string, string>> CustomHeaderItems { get; private set; }
+        protected internal List<KeyValuePair<string, string>> CustomHeaderItems { get; private set; }
 
 
         private int m_StateCode;


### PR DESCRIPTION
In some scenarios it is neccesary to create an extended WebSocket and ProtocolProcessor, e.g. to add certain steps to the handshake (for an example see: https://github.com/Atmosphere/WebSocket4Net/tree/AtmosphereFrameworkSupport).
With the current version of WebSocket4Net this requires either modifications to the existing framework code (as seen in the example) or at least modification of the WebSocket4Net assembly (when using partial classes).
I made some modifications so an extended WebSocket and ProtocolProcessor can be created _outside_ the WebSocket4Net assembly and have (protected) access to the required attributes. This is just a proposal, but it would make the creation of custom extension (e.g. for the Atmosphere protocol) a lot easier.
