### PR TITLE
CA1063: Implement IDisposable Correctly

### DIFF
--- a/WebSocket4Net/JsonWebSocket.cs
+++ b/WebSocket4Net/JsonWebSocket.cs
@@ -9,9 +9,10 @@ namespace WebSocket4Net
     /// <summary>
     /// WebSocket client wrapping which serializes/deserializes objects by JSON
     /// </summary>
-    public partial class JsonWebSocket
+    public partial class JsonWebSocket : IDisposable
     {
         private WebSocket m_WebSocket;
+        private bool m_disposed = false;
 
         /// <summary>
         /// Gets or sets a value indicating whether [enable auto send ping].
@@ -433,6 +434,33 @@ namespace WebSocket4Net
 
                 return executor;
             }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (m_disposed)
+                return;
+
+            if (disposing)
+            {
+                if (m_WebSocket != null)
+                {
+                    m_WebSocket.Dispose();
+                }
+            }
+
+            m_disposed = true;
+        }
+
+        ~JsonWebSocket()
+        {
+            Dispose(false);
         }
     }
 }

--- a/WebSocket4Net/WebSocket.cs
+++ b/WebSocket4Net/WebSocket.cs
@@ -120,6 +120,8 @@ namespace WebSocket4Net
         public bool NoDelay { get; set; }
 #endif
 
+        private bool m_disposed = false;
+
         static WebSocket()
         {
             m_ProtocolProcessorFactory = new ProtocolProcessorFactory(new Rfc6455Processor(), new DraftHybi10Processor(), new DraftHybi00Processor());
@@ -640,17 +642,41 @@ namespace WebSocket4Net
             OnError(new ErrorEventArgs(e));
         }
 
-        void IDisposable.Dispose()
+        public void Dispose()
         {
-            var client = Client;
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-            if (client != null)
+        protected virtual void Dispose(bool disposing)
+        {
+            if (m_disposed)
+                return;
+
+            if (disposing)
             {
-                if (client.IsConnected)
-                    client.Close();
+                var client = Client;
 
-                Client = null;
+                if (client != null)
+                {
+                    if (client.IsConnected)
+                        client.Close();
+
+                    Client = null;
+                }
+
+                if (m_WebSocketTimer != null)
+                {
+                    m_WebSocketTimer.Dispose();
+                }
             }
+
+            m_disposed = true;
+        }
+
+        ~WebSocket()
+        {
+            Dispose(false);
         }
     }
 }


### PR DESCRIPTION
The WebSocket type Dispose method had default access of internal which prevents a consuming type owning a WebSocket instance from correctly implementing IDisposable. 

WebSocket also owns a System.Threading.Timer instance that is not disposed, and does not implement an object finalizer according to the .NET framework recommendations for cleaning up unmanaged resources. Additionally JsonWebSocket does not implement IDisposable despite owning a WebSocket instance. 
