### PR TITLE
Fix receiving of binary data over 1016 bytes

### DIFF
--- a/WebSocket4Net/WebSocketCommandInfo.cs
+++ b/WebSocket4Net/WebSocketCommandInfo.cs
@@ -121,6 +121,8 @@ namespace WebSocket4Net
                     }
 
                     frame.InnerData.CopyTo(resultBuffer, offset, copied, length);
+
+                    copied += length;
                 }
 
                 Data = resultBuffer;


### PR DESCRIPTION
When receiving large binary data the client incorrectly presents the data to the client. While the array will be the correct size, only the first 1016 bytes will be populated. This increments the number of bytes copied so it will not overwrite data.