### PR TITLE
Control frames fix

### DIFF
--- a/WebSocket4Net/Protocol/DraftHybi10DataReader.cs
+++ b/WebSocket4Net/Protocol/DraftHybi10DataReader.cs
@@ -59,7 +59,15 @@ namespace WebSocket4Net.Protocol
                 {
                     WebSocketCommandInfo commandInfo;
 
-                    if (m_Frame.FIN)
+                    // Control frames MAY be injected in the middle of
+                    // a fragmented message.Control frames themselves MUST NOT be
+                    // fragmented.
+                    if (m_Frame.IsControlFrame)
+                    {
+                        commandInfo = new WebSocketCommandInfo(m_Frame);
+                        m_Frame.Clear();
+                    }
+                    else if (m_Frame.FIN)
                     {
                         if (m_PreviousFrames != null && m_PreviousFrames.Count > 0)
                         {

--- a/WebSocket4Net/Protocol/WebSocketDataFrame.cs
+++ b/WebSocket4Net/Protocol/WebSocketDataFrame.cs
@@ -20,6 +20,24 @@ namespace WebSocket4Net.Protocol
             m_InnerData.ClearSegements();
         }
 
+        public bool IsControlFrame
+        {
+            get
+            {
+                sbyte opCode = OpCode;
+
+                switch (opCode)
+                {
+                    case WebSocket4Net.OpCode.Ping:
+                    case WebSocket4Net.OpCode.Pong:
+                    case WebSocket4Net.OpCode.Close:
+                        return true;
+                }
+
+                return false;
+            }
+        }
+
         public bool FIN
         {
             get { return ((m_InnerData[0] & 0x80) == 0x80); }


### PR DESCRIPTION
This is an attempt to solve [this issue](https://github.com/vtortola/WebSocketListener/issues/47).

Due to The WebSocket Protocol RFC

   o  Control frames (see Section 5.5) MAY be injected in the middle of
      a fragmented message.  Control frames themselves MUST NOT be
      fragmented.

However, it seems that WebSocket4Net currently lacks this: when receiving a frame it checks if the frame has the FIN flag and if it does it ends the fragmented message. However, control frames might be injected in the middle of a fragmented message. Those shouldn't be considered as part of the whole fragmented message and should be treated separately.

My apologies for non informative commit messages and for two commits. I tried to edit these files on my computer, but if I do so it looks as I removed and added the entire whole files, so instead I edited online.

Elad