### PR TITLE
Call onClosed() in CloseWithoutHandshake()

### DIFF
--- a/WebSocket4Net/WebSocket.cs
+++ b/WebSocket4Net/WebSocket.cs
@@ -585,7 +585,7 @@ namespace WebSocket4Net
 
             //Nothing to do if closing is in progress
 
-            if (m_StateCode == WebSocketStateConst.Closed) return;
+            if (m_StateCode == WebSocketStateConst.Closing) return;
 
             //The websocket never be opened
             if (Interlocked.CompareExchange(ref m_StateCode, WebSocketStateConst.Closed, WebSocketStateConst.None)

--- a/WebSocket4Net/WebSocket.cs
+++ b/WebSocket4Net/WebSocket.cs
@@ -611,10 +611,16 @@ namespace WebSocket4Net
 
             //Disable auto ping
             ClearTimer();
-            //Set closing hadnshake checking timer
-            m_WebSocketTimer = new Timer(CheckCloseHandshake, null, 5 * 1000, Timeout.Infinite);
+
+            //We should return only when all IO is compleeted and it's safe to call Dispose() or Open()
+            
+            ////Set closing hadnshake checking timer
+            ////m_WebSocketTimer = new Timer(CheckCloseHandshake, null, 5 * 1000, Timeout.Infinite);
 
             ProtocolProcessor.SendCloseHandshake(this, statusCode, reason);
+            Thread.Sleep(5*1000);
+            CheckCloseHandshake(null);
+
         }
 
         private void CheckCloseHandshake(object state)
@@ -637,7 +643,11 @@ namespace WebSocket4Net
             var client = Client;
 
             if (client != null)
+            {
                 client.Close();
+                //We should set sokect to the Colsed state and fire an event if necessary
+                OnClosed();
+            }
         }
 
         protected void ExecuteCommand(WebSocketCommandInfo commandInfo)

--- a/WebSocket4Net/WebSocket.cs
+++ b/WebSocket4Net/WebSocket.cs
@@ -583,6 +583,10 @@ namespace WebSocket4Net
         {
             m_ClosedArgs = new ClosedEventArgs((short)statusCode, reason);
 
+            //Nothing to do if closing is in progress
+
+            if (m_StateCode == WebSocketStateConst.Closed) return;
+
             //The websocket never be opened
             if (Interlocked.CompareExchange(ref m_StateCode, WebSocketStateConst.Closed, WebSocketStateConst.None)
                     == WebSocketStateConst.None)
@@ -611,16 +615,10 @@ namespace WebSocket4Net
 
             //Disable auto ping
             ClearTimer();
-
-            //We should return only when all IO is compleeted and it's safe to call Dispose() or Open()
-            
-            ////Set closing hadnshake checking timer
-            ////m_WebSocketTimer = new Timer(CheckCloseHandshake, null, 5 * 1000, Timeout.Infinite);
+            //Set closing hadnshake checking timer
+            m_WebSocketTimer = new Timer(CheckCloseHandshake, null, 5 * 1000, Timeout.Infinite);
 
             ProtocolProcessor.SendCloseHandshake(this, statusCode, reason);
-            Thread.Sleep(5*1000);
-            CheckCloseHandshake(null);
-
         }
 
         private void CheckCloseHandshake(object state)


### PR DESCRIPTION
CloseWithoutHandshake() doesn't set m_StateCode to WebSocketStateConst.Closed by calling  onClosed(), but looks like it should, because "Close" command's response handler calls CloseWithoutHandshake()
//Close handshake was sent from client side, now got a handshake response
            if (session.StateCode == WebSocketStateConst.Closing)
            {
                session.CloseWithoutHandshake();
                return;
            }  
            …

And then CheckCloseHandshake() checks if m_StateCode equals WebSocketStateConst.Closed

 private void CheckCloseHandshake(object state)
        {
            if (m_StateCode == WebSocketStateConst.Closed)
                return;
           …

thus, CloseWithoutHandshake() will be called twice. Even after that, m_StateCode stays WebSocketStateConst.Closing and Closed event doesn't fire.

Also, it's good to have check for  m_StateCode == WebSocketStateConst.Closing in Close() to prevent of start of two closing process