### PR TITLE
Fixed User-Agent header typo

### DIFF
--- a/WebSocket4Net/WebSocket.cs
+++ b/WebSocket4Net/WebSocket.cs
@@ -45,7 +45,7 @@ namespace WebSocket4Net
         /// </value>
         public int AutoSendPingInterval { get; set; }
 
-        protected const string UserAgentKey = "UserAgent";
+        protected const string UserAgentKey = "User-Agent";
 
         internal IProtocolProcessor ProtocolProcessor { get; private set; }
 


### PR DESCRIPTION
The current `UserAgent` string is not correct according to [RFC7231](https://tools.ietf.org/html/rfc7231#section-5.5.3), or [RFC2616](https://tools.ietf.org/html/rfc2616#section-14.43) for that matter. It should be `User-Agent` :smile: