### PR TITLE
Update ProtocolProcessorBase.cs

### DIFF
--- a/WebSocket4Net/Protocol/ProtocolProcessorBase.cs
+++ b/WebSocket4Net/Protocol/ProtocolProcessorBase.cs
@@ -50,7 +50,7 @@ namespace WebSocket4Net.Protocol
         {
             var parts = verbLine.Split(s_SpaceSpliter, 3, StringSplitOptions.RemoveEmptyEntries);
 
-            if (parts.Length < 3)
+            if (parts.Length < 2)
                 return false;
 
             if (!parts[0].StartsWith("HTTP/"))


### PR DESCRIPTION
When validating the verbLine, do not require that the optional description parameter be present.  The description is not required in the standard and some web servers (like the built in web server in grails) do not provide it.