### PR TITLE
Update the project URL for NuGet package

### DIFF
--- a/nuget/WebSocket4Net.nuspec
+++ b/nuget/WebSocket4Net.nuspec
@@ -6,7 +6,7 @@
     <authors>Kerry Jiang</authors>
     <owners>Kerry Jiang</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
-    <projectUrl>http://websocket4net.codeplex.com/</projectUrl>
+    <projectUrl>https://github.com/kerryjiang/WebSocket4Net/</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>WebSocket4Net is a .NET websocket client implemtation. It originates from SuperWebSocket WebSocket Client. For better developing of the websocket client, it was separated from SuperWebSocket and was renamed to WebSocket4Net.</description>
     <tags>WebSocket, WebSocket4Net, SuperWebSocket</tags>


### PR DESCRIPTION
The project URL is still pointing to the old CodePlex site. I think it should point to GitHub instead.